### PR TITLE
feat: New help module

### DIFF
--- a/src/errors/session-not-found.ts
+++ b/src/errors/session-not-found.ts
@@ -1,0 +1,7 @@
+import { __ } from "i18n";
+
+export default class SessionNotFoundError extends Error {
+    constructor() {
+        super(__("Specified session not found."));
+    }
+}

--- a/src/manager-instance.ts
+++ b/src/manager-instance.ts
@@ -4,6 +4,7 @@ import Directory from "./modules/directory";
 import Client from "./modules/client";
 import Command from "./modules/command";
 import Prompt from "./modules/prompt";
+import Sessions from "./modules/sessions";
 import Help from "./modules/help";
 
 let flags: { [key: string]: unknown } = {};
@@ -20,6 +21,7 @@ export { flags, arguments_ };
 export default new ModuleManager([
     new Directory(),
     new Help(),
+    new Sessions(),
     new Client(),
     new Command(),
     new Prompt()

--- a/src/modules/sessions.ts
+++ b/src/modules/sessions.ts
@@ -1,0 +1,92 @@
+import { AxiosInstance } from "axios";
+import chalk from "chalk";
+import { sprintf } from "sprintf-js";
+import { __ } from "i18n";
+
+import { default as manager, flags } from "../manager-instance";
+
+import SessionNotFoundError from "../errors/session-not-found";
+
+import Module from "./base";
+
+export interface Session {
+    sessionId: number,
+    name: string,
+    hostname: string,
+    token?: string,
+    client: AxiosInstance
+}
+
+export interface SessionOptions {
+    name: string,
+    hostname: string,
+    token?: string,
+    client: AxiosInstance
+}
+
+export default class Sessions extends Module {
+    constructor(private sessions: Session[] = [], private attaching: Session[] = [], private nowId = 0) {
+        super("Sessions Manager", "Manage sessions on-demand.");
+    }
+
+    private attach(name: string) {
+        const foundSession = this.sessions.map((session: Session) => session.name).indexOf(name);
+
+        if (foundSession === -1) {
+            throw new SessionNotFoundError();
+        }
+
+        this.attaching[0] = this.sessions[foundSession];
+    }
+
+    private create(session: SessionOptions) {
+        const { logger } = manager;
+        const verbose = flags.verbose as boolean;
+
+        if ("token" in session) {
+            logger.info(sprintf(__("Creating authenticated session %s..."), chalk.cyanBright(session.name)), verbose);
+        } else {
+            logger.info(sprintf(__("Creating session %s..."), chalk.cyanBright(session.name)), verbose);
+        }
+
+        if ("token" in session) {
+            this.sessions.push({
+                client: session.client,
+                hostname: session.hostname,
+                name: session.name,
+                sessionId: this.nowId,
+                token: session.token
+            });
+        } else {
+            this.sessions.push({
+                client: session.client,
+                hostname: session.hostname,
+                name: session.name,
+                sessionId: this.nowId
+            });
+        }
+
+        this.nowId++;
+    }
+
+    public init(): Promise<void> {
+        this.enabled = true;
+
+        return Promise.resolve();
+    }
+
+    public use(): { attach: (name: string) => void, create: (session: SessionOptions) => void, nowSession?: Session, sessions: Session[] } {
+        return {
+            attach: this.attach,
+            create: this.create,
+            nowSession: this.attaching ? this.attaching[0] : undefined,
+            sessions: this.sessions
+        };
+    }
+
+    public close(): Promise<void> {
+        this.enabled = false;
+
+        return Promise.resolve();
+    }
+}

--- a/src/utils/hostname.ts
+++ b/src/utils/hostname.ts
@@ -1,0 +1,35 @@
+import { sprintf } from "sprintf-js";
+import { __ } from "i18n";
+import chalk from "chalk";
+
+import { flags, default as manager } from "../manager-instance";
+
+export default (hostname: string): string => {
+    const verbose = flags.verbose as boolean;
+    const { logger } = manager;
+
+    let host;
+
+    try {
+        host = new URL(hostname.replace("localhost", "127.0.0.1"));
+    } catch {
+        host = new URL("http://" + hostname.replace("localhost", "127.0.0.1"));
+    }
+
+    if (!host.port) {
+        host.port = "810";
+        logger.info(sprintf(__("The port didn't specify in hostname, using the default port %s."), chalk.yellowBright(810)), verbose);
+    }
+
+    if (host.protocol === "https:") {
+        host.protocol = "http:";
+        logger.warn(__("The server doesn't support HTTPS protocol, using HTTP protocol instead."), verbose);
+    }
+
+    if (host.pathname !== "/") {
+        host.pathname = "/";
+        logger.warn(__("The hostname doesn't support paths, using the root path."), verbose);
+    }
+
+    return host.hostname;
+};

--- a/src/utils/lexing.ts
+++ b/src/utils/lexing.ts
@@ -2,7 +2,7 @@ export const regexes = {
     command: "(?<=^|;|\\|)[A-Za-z]+(?= ?)",
     comment: "(#|\\/\\/).*$",
     digits: "(\\d+#\\d+|\\d+#(?! )|\\d+)(([Ee])[+-]?)?(\\d+#\\d+|\\d+#(?! )|\\d+)",
-    operators: "([%&*+/^|-]|\\*\\*|\\|\\|)",
+    operators: "([&|]|\\|\\|)",
     semicolon: ";"
 };
 


### PR DESCRIPTION
さすがに今の`Help`の実装がクソすぎるので、インターフェースをもとに文字列をCLIコンポーネントを用いてビルドできるようにします。
現行`string[].join("\n")`だよ。やばくね？
