### PR TITLE
refactor: Use terminal-kit prompt instead of enquirer

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
         "cli-truncate": "^2.1.0",
         "command-line-args": "^5.1.1",
         "dot-object": "2.1.4",
-        "enquirer": "^2.3.6",
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "i18n": "^0.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,6 @@ dependencies:
   cli-truncate: 2.1.0
   command-line-args: 5.1.1
   dot-object: 2.1.4
-  enquirer: 2.3.6
   figures: 3.2.0
   fs-extra: 9.1.0
   i18n: 0.13.2_supports-color@8.1.1
@@ -856,6 +855,7 @@ packages:
     resolution:
       integrity: sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
   /ansi-colors/4.1.1:
+    dev: true
     engines:
       node: '>=6'
     resolution:
@@ -1846,6 +1846,7 @@ packages:
   /enquirer/2.3.6:
     dependencies:
       ansi-colors: 4.1.1
+    dev: true
     engines:
       node: '>=8.6'
     resolution:
@@ -6384,7 +6385,6 @@ specifiers:
   cli-truncate: ^2.1.0
   command-line-args: ^5.1.1
   dot-object: 2.1.4
-  enquirer: ^2.3.6
   eslint: ^7.19.0
   eslint-plugin-eslint-comments: 3.2.0
   eslint-plugin-import: ^2.22.1

--- a/src/modules/native/clients.ts
+++ b/src/modules/native/clients.ts
@@ -5,10 +5,10 @@ import axios, { AxiosInstance } from "axios";
 import chalk from "chalk";
 import figures from "figures";
 import msgpack from "msgpack";
-import { prompt } from "enquirer";
 import { sprintf } from "sprintf-js";
 import { v4 } from "uuid";
 import { __ } from "i18n";
+import { terminal } from "terminal-kit";
 
 import Timer from "../../utils/timer";
 
@@ -71,11 +71,9 @@ export default class Clients {
                 try {
                     logger.info(__("No token found, asking to user."), verbose, name);
 
-                    token = (await prompt({
-                        message: __("Enter token to connect"),
-                        name: "token",
-                        type: "password"
-                    }) as { token: string }).token;
+                    token = await terminal(chalk.bold(__("Enter token to connect")) + chalk` {dim >>>} `).inputField({
+                        echoChar: true
+                    }).promise;
                 } catch {
                     throw new KeyboardInterruptError();
                 }


### PR DESCRIPTION
enquirerとterminal-kitではstdioの扱い方が少々違うので、競合が発生しないようにterminal-kitのみで運用することになりました。
enquirerの場合はプロンプト時にstdoutのlockやresumeなど手間がかかる作業が多くなっていましたが、terminal-kitでは関数を単一で使用しても正常にstdioを扱うことができます。
恐らく一文字ずつのトリガになんかあるんでしょうね。